### PR TITLE
Point to correct ffmpeg location by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# gitginore template for creating Snap packages
+# website: https://snapcraft.io/
+
+parts/
+prime/
+stage/
+*.snap
+
+# Snapcraft global state tracking data(automatically generated)
+# https://forum.snapcraft.io/t/location-to-save-global-state/768
+/snap/.snapcraft/
+
+# Source archive packed by `snapcraft cleanbuild` before pushing to the LXD container
+/*_source.tar.bz2

--- a/default-preferences/ensure-defaults.sh
+++ b/default-preferences/ensure-defaults.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# This script modifies the preferences of an old OpenToonz snap version in order to correctly set the ffmpeg path.
+#
+
+# Only run this command once so we don't add extra startup time after the upgrade.
+if [[ ! -f "$SNAP_USER_COMMON/ffmpeg-path-fixed" ]]; then
+    PREFERENCES_FILE="$SNAP_USER_COMMON/.config/OpenToonz/stuff/profiles/layouts/settings.$USER/preferences.ini"
+
+    # If the file doesn't exist, it will be created by OpenToonz using the correct template in this snap, so no action is needed.
+    if [[ -f "$PREFERENCES_FILE" ]]; then
+      crudini --set "$PREFERENCES_FILE" General ffmpegPath "/snap/opentoonz/current/usr/bin/"
+    fi
+    touch "$SNAP_USER_COMMON/ffmpeg-path-fixed"
+fi
+
+# Run the next command in the command-chain
+exec "$@"

--- a/default-preferences/preferences.ini
+++ b/default-preferences/preferences.ini
@@ -1,0 +1,2 @@
+[General]
+ffmpegPath=/snap/opentoonz/current/usr/bin/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -59,10 +59,6 @@ apps:
     plugs:
       - home
 
-layout:
-  /usr/bin/ffmpeg:
-    bind-file: $SNAP/usr/bin/ffmpeg
-
 parts:
   libmypaint:
     source: https://github.com/mypaint/libmypaint.git

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,7 +23,10 @@ apps:
       DISABLE_WAYLAND: 1
       HOME: "$SNAP_USER_COMMON"
       LD_LIBRARY_PATH: "$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/blas:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/lapack"
-    command: desktop-launch $SNAP/bin/opentoonz
+    command: bin/opentoonz
+    command-chain:
+      - bin/desktop-launch
+      - snap/command-chain/ensure-defaults.sh
     plugs:
       - desktop
       - desktop-legacy
@@ -200,6 +203,17 @@ parts:
         - liburiparser1
         - libxerces-c3.2
         - odbcinst1debian2
+
+  # Inject default preferences to point to ffmpeg in the snap itself
+  default-preferences:
+    after: [ opentoonz ]
+    plugin: dump
+    source: default-preferences
+    organize:
+      preferences.ini: share/opentoonz/stuff/profiles/layouts/settings/preferences.ini
+      ensure-defaults.sh: snap/command-chain/ensure-defaults.sh
+    stage-packages:
+      - crudini
 
   desktop-qt5:
       build-packages:


### PR DESCRIPTION
As mentioned [on the forum](https://forum.snapcraft.io/t/snapcrafters-snaps-call-for-testing/24416/15), OpenToonz can't find ffmpeg in the snap. The [code expects](https://github.com/opentoonz/opentoonz/blob/5aa5de6505d2612661466a707fdfd8392082cae5/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp#L23-L31)

* either a config option pointing to the directory containing ffmpeg
* or ffmpeg being in the current working directory. (The comment in the source incorrectly assumes this is the root directory of OpenToonz; that is only the case on Windows, not on Linux).

So the only good option in order to have ffmpeg work by default in this snap is to configure the path of ffmpeg in the preferences.

This PR does that in two ways:

* It adds a default `preferences.ini` which will be used to populate user preferences when the application first starts up. This, however, will not fix the issue for existing installations of this Snap.
* It adds the `ensure-defaults.sh` scripts to insert/modify the ffmpeg path in existing user preferences. This, however, will not fix the issue for new installations of this Snap.

Both of these combined fix the issue for both new and existing installations of this snap.

To test this, install the snap, run it, close the "opentoonz startup" dialog and choose the menu item `Render` > `Fast Render to MP4`. You should see a box "the command cannot be executed because the scene is empty" instead of "ffmpeg not found".